### PR TITLE
Adding user seed to ollamaVision request

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,7 @@
+10-07-2025:
+
+Adding user seed to OllamaVision request.
+
 10-06-2025:
 
 Increased temperature limits in OptionsV2.

--- a/CompfyuiOllama.py
+++ b/CompfyuiOllama.py
@@ -98,6 +98,9 @@ request query params:
 - query: {query}
 - url: {url}
 - model: {model}
+- keep_alive: {keep_alive} minutes
+- options: {options}
+- format: {format}
 
 """)
         

--- a/CompfyuiOllama.py
+++ b/CompfyuiOllama.py
@@ -88,10 +88,7 @@ class OllamaVision:
         client = Client(host=url)
 
         options = {
-            "format": format,
-            "seed": seed,
-            "keep_alive": str(keep_alive) + "m",
-            "debug": True if debug == "enable" else False
+            "seed": seed
         }
 
         if debug == "enable":
@@ -106,7 +103,7 @@ request query params:
         
     
 
-        response = client.generate(model=model, prompt=query, images=images_binary, options=options)
+        response = client.generate(model=model, prompt=query, images=images_binary, options=options, keep_alive=str(keep_alive) + "m", format=format)
 
         if debug == "enable":
             print("[Ollama Vision]\nResponse:\n")

--- a/CompfyuiOllama.py
+++ b/CompfyuiOllama.py
@@ -87,6 +87,13 @@ class OllamaVision:
 
         client = Client(host=url)
 
+        options = {
+            "format": format,
+            "seed": seed,
+            "keep_alive": str(keep_alive) + "m",
+            "debug": True if debug == "enable" else False
+        }
+
         if debug == "enable":
             print(f"""[Ollama Vision]
 request query params:
@@ -96,8 +103,10 @@ request query params:
 - model: {model}
 
 """)
+        
+    
 
-        response = client.generate(model=model, prompt=query, images=images_binary, keep_alive=str(keep_alive) + "m", format=format)
+        response = client.generate(model=model, prompt=query, images=images_binary, options=options)
 
         if debug == "enable":
             print("[Ollama Vision]\nResponse:\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-ollama"
 description = "Custom ComfyUI Nodes for interacting with [a/Ollama](https://ollama.com/) using the [a/ollama python client](https://github.com/ollama/ollama-python).\nIntegrate the power of LLMs into CompfyUI workflows easily."
-version = "2.0.5"
+version = "2.0.6"
 license = { file = "LICENSE" }
 dependencies = ["ollama"]
 


### PR DESCRIPTION
Hi @stavsap and @vilanele,

I recognized, that the user seed (as introduced with https://github.com/stavsap/comfyui-ollama/pull/52) isn't used in the actual ollama_vision generate call. So it is still using a random seed on each call.

Here is my proposal for a fix. Please let me know, if you want me to change anything!

