### PR TITLE
feat: Add thinking levels and vRAM management to Ollama nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv
 .idea
 saved_context
 __pycache__
+.vscode

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ A node for **conversational interaction** using the dedicated Ollama chat endpoi
     -   Conversation history is handled natively within the node instance.
     -   Dedicated history outputs for **chaining multiple chat nodes**.
     -   Option to **reset** the current conversation history on demand.
+    -   **Thinking Mode:** Supports both boolean (on/off) and granular levels (low/medium/high) for compatible models
+        -   Boolean mode works with all models that support it (off by default for models that don't support it)
+        -   Level mode (low/medium/high) is available for gpt-oss models
 
 Inputs:
 
@@ -133,6 +136,13 @@ Outputs:
 ### OllamaConnectivity
 
 A node responsible only fot the connectivity to the ollama server
+
+Features:
+-   Set Ollama URL
+-   Set Ollama Model
+-   **Reconnect**: Reconnect to the Ollama server and update models list
+-   **Clear memory**: Clear GPU memory used by loaded LLMs
+*This is particularly helpful when working with large models or running multiple inference workflows.*
 
 ### OllamaOptions
 

--- a/web/js/OllamaNode.js
+++ b/web/js/OllamaNode.js
@@ -20,8 +20,10 @@ app.registerExtension({
         const urlWidget = this.widgets.find((w) => w.name === "url");
         const modelWidget = this.widgets.find((w) => w.name === "model");
         let refreshButtonWidget = {};
+        let clearMemoryButtonWidget = {};
         if (nodeData.name === "OllamaConnectivityV2") {
           refreshButtonWidget = this.addWidget("button", "🔄 Reconnect");
+          clearMemoryButtonWidget = this.addWidget("button", "🗑️ Clear memory");
         }
 
         const fetchModels = async (url) => {
@@ -81,8 +83,43 @@ app.registerExtension({
           console.debug("Updated modelWidget.value:", modelWidget.value);
         };
 
+        const clearMemory = async () => {
+          clearMemoryButtonWidget.name = "⏳ Clearing...";
+          const url = urlWidget.value;
+          const model = modelWidget.value;
+          const response = await fetch("/ollama/clear_memory", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              url,
+              model,
+            }),
+          });
+          if (response.ok) {
+            console.debug("Memory cleared");
+            app.extensionManager.toast.add({
+              severity: "success",
+              summary: "Ollama memory cleared",
+              detail: "Memory cleared successfully",
+              life: 5000,
+            });
+          } else {
+            console.error("Error clearing memory:", response);
+            app.extensionManager.toast.add({
+              severity: "error",
+              summary: "Ollama memory clear error",
+              detail: response.error,
+              life: 5000,
+            });
+          }
+          clearMemoryButtonWidget.name = "🗑️ Clear memory";
+        };
+
         urlWidget.callback = updateModels;
         refreshButtonWidget.callback = updateModels;
+        clearMemoryButtonWidget.callback = clearMemory
 
         const dummy = async () => {
           // calling async method will update the widgets with actual value from the browser and not the default from Node definition.


### PR DESCRIPTION
## Summary

Adds support for thinking levels and GPU memory management to Ollama nodes.

## Changes

**OllamaChat:**
- Support for thinking levels (low/medium/high) for gpt-oss models
- Maintains backward compatibility with boolean mode
- Boolean mode remains default for unsupported models

**OllamaConnectivity:**
- New "Clear memory" button to free GPU vRAM
- Improves resource management for multi-model workflows

**Documentation:**
- Updated README with feature documentation

## Testing
Tested with gpt-oss:120-cloud. Verified backward compatibility and vRAM management functionality.

## Changelog suggestion

### Added
- OllamaChat: Thinking levels (low/medium/high) for gpt-oss models
- OllamaConnectivity: "Clear memory" button

### Changed
- OllamaChat: Thinking mode supports boolean and level-based modes

Let me know if you'd like any changes or have questions about the implementation!